### PR TITLE
feat: Implement project modal and center portfolio items

### DIFF
--- a/src/assets/irnsolar.svg
+++ b/src/assets/irnsolar.svg
@@ -1,0 +1,1 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="400" height="200" style="fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)" /></svg>

--- a/src/assets/ordermanagement.svg
+++ b/src/assets/ordermanagement.svg
@@ -1,0 +1,1 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="400" height="200" style="fill:rgb(255,0,0);stroke-width:3;stroke:rgb(0,0,0)" /></svg>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,24 @@
+// src/components/Modal.jsx
+import React from 'react';
+
+const Modal = ({ project, onClose }) => {
+  if (!project) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-75 flex justify-center items-center z-50" onClick={onClose}>
+      <div className="relative bg-gray-900 rounded-lg p-8 max-w-2xl w-full mx-4" onClick={(e) => e.stopPropagation()}>
+        <button onClick={onClose} className="absolute top-4 right-4 text-white text-3xl leading-none hover:text-gray-400">&times;</button>
+        <img src={project.imageUrl} alt={project.title} className="w-full h-64 object-cover rounded-lg mb-6" />
+        <h2 className="text-3xl font-bold text-cyan-400">{project.title}</h2>
+        <p className="text-gray-400 mt-2">{project.description}</p>
+        <p className="text-sm font-semibold text-gray-500 mt-4 mb-6">{project.tech}</p>
+        <div className="flex justify-start gap-4">
+          <a href={project.projectUrl} target="_blank" rel="noopener noreferrer" className="bg-cyan-500 text-white py-2 px-4 rounded hover:bg-cyan-600 transition-colors">View Project</a>
+          <a href={project.githubUrl} target="_blank" rel="noopener noreferrer" className="bg-gray-700 text-white py-2 px-4 rounded hover:bg-gray-600 transition-colors">GitHub</a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,28 +1,55 @@
 // src/components/Projects.jsx
-import React from 'react';
+import React, { useState } from 'react';
+import Modal from './Modal';
+import irnSolarImage from '../assets/irnsolar.svg';
+import orderManagementImage from '../assets/ordermanagement.svg';
 
 // Placeholder data - we'll replace this with your actual projects
 const projectData = [
-  { title: "IRN Solar House", description: "A modern website for a solar energy company, built with React and Vite.", tech: "React, Firebase, Tailwind CSS" },
-  { title: "Order Management App", description: "A web application for managing customer orders and production planning.", tech: "React, Vite, Firebase" },
-  ];
+  {
+    title: "IRN Solar House",
+    description: "A modern website for a solar energy company, built with React and Vite.",
+    tech: "React, Firebase, Tailwind CSS",
+    imageUrl: irnSolarImage,
+    projectUrl: "https://irnsolar.com",
+    githubUrl: "https://github.com/your-username/irn-solar-house"
+  },
+  {
+    title: "Order Management App",
+    description: "A web application for managing customer orders and production planning.",
+    tech: "React, Vite, Firebase",
+    imageUrl: orderManagementImage,
+    projectUrl: "https://order-management-app.com",
+    githubUrl: "https://github.com/your-username/order-management-app"
+  },
+];
 
 const Projects = () => {
+  const [selectedProject, setSelectedProject] = useState(null);
+
+  const openModal = (project) => {
+    setSelectedProject(project);
+  };
+
+  const closeModal = () => {
+    setSelectedProject(null);
+  };
+
   return (
     <section id="projects" className="py-20 bg-gray-800 text-white">
       <div className="container mx-auto px-4">
         <h2 className="text-4xl text-center font-bold mb-12">My Portfolio</h2>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div className="flex flex-wrap justify-center gap-8">
           {projectData.map((project, index) => (
-            <div key={index} className="bg-gray-900 rounded-lg p-6 transform hover:-translate-y-2 transition-transform duration-300">
+            <div key={index} onClick={() => openModal(project)} className="bg-gray-900 rounded-lg p-6 transform hover:-translate-y-2 transition-transform duration-300 w-full md:w-1/2 lg:w-1/3 cursor-pointer">
               <h3 className="text-2xl font-bold mb-2 text-cyan-400">{project.title}</h3>
               <p className="text-gray-400 mb-4">{project.description}</p>
               <p className="text-sm font-semibold text-gray-500">{project.tech}</p>
-              {/* You can add links here later */}
             </div>
           ))}
         </div>
       </div>
+      <Modal project={selectedProject} onClose={closeModal} />
     </section>
   );
 };


### PR DESCRIPTION
This commit introduces a modal popup for the portfolio projects and centers the project cards on the page.

- Updated the project data structure to include image, project, and GitHub URLs.
- Modified the layout of the projects section to center the project cards.
- Created a reusable modal component to display project details.
- Implemented state and event handlers to manage the modal's visibility.
- Styled the modal using Tailwind CSS to match the website's theme.
- Added placeholder SVG images for the projects.